### PR TITLE
Basically just a typo

### DIFF
--- a/ESPKey.ino
+++ b/ESPKey.ino
@@ -562,7 +562,7 @@ void setup() {
   DBG_OUTPUT_PORT.println("Hostname: " + dhcp_hostname);
 
   if (!SPIFFS.begin()) {
-    Serial.println(F("Failed to mount file system"));
+    DBG_OUTPUT_PORT.println(F("Failed to mount file system"));
     return;
   } else {
     Dir dir = SPIFFS.openDir("/");


### PR DESCRIPTION
I noticed all debug messages but one are sent to `DBG_OUTPUT_PORT`, which is defined as `Serial`. The outlier directly references `Serial` instead of `DBG_OUTPUT_PORT`. This is a pedantic correction if anything, and should have no effect on the operation of the sketch. I've corrected it such that all of the debug prints go to `DBG_OUTPUT_PORT` for consistency.